### PR TITLE
feat: Switch to HuggingFace embeddings and update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@
 
 ## セットアップ手順
 
-1. **Python 3.12 以上を用意**
+1. **Ryeのインストール**
+   Ryeがインストールされていない場合は、[公式サイト](https://rye-up.com/)からインストールしてください。
+
 2. **依存パッケージのインストール**
 
    ```sh
-   pip install -r requirements.lock
-   # または
    rye sync
    ```
 
@@ -32,7 +32,7 @@
 Notionからデータを取得し、ベクトルDBを作成します。
 
 ```sh
-python src/vector.py
+rye run python src/vector.py
 ```
 
 ---
@@ -42,7 +42,7 @@ python src/vector.py
 Chainlitを使ってチャットUIを起動します。
 
 ```sh
-chainlit run src/app.py
+rye run chainlit run src/app.py
 ```
 
 起動後、表示されるURLにアクセスしてください。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ dependencies = [
     "fastparquet>=2024.5.0",
     "chainlit>=1.3.2",
     "pydantic==2.10.1",
+    "langchain-huggingface>=0.3.0",
+    "sentence-transformers>=5.0.0",
 ]
 readme = "README.md"
 requires-python = ">= 3.12"

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -15,7 +15,6 @@ aiofiles==23.2.1
 aiohappyeyeballs==2.4.4
     # via aiohttp
 aiohttp==3.11.11
-    # via langchain
     # via langchain-community
 aiosignal==1.3.2
     # via aiohttp
@@ -64,6 +63,10 @@ fastapi==0.115.6
     # via chainlit
 fastparquet==2024.11.0
     # via rag-decision-record
+filelock==3.18.0
+    # via huggingface-hub
+    # via torch
+    # via transformers
 filetype==1.2.0
     # via chainlit
 frozenlist==1.5.0
@@ -71,6 +74,8 @@ frozenlist==1.5.0
     # via aiosignal
 fsspec==2024.12.0
     # via fastparquet
+    # via huggingface-hub
+    # via torch
 googleapis-common-protos==1.66.0
     # via opentelemetry-exporter-otlp-proto-grpc
     # via opentelemetry-exporter-otlp-proto-http
@@ -80,6 +85,8 @@ h11==0.14.0
     # via httpcore
     # via uvicorn
     # via wsproto
+hf-xet==1.1.5
+    # via huggingface-hub
 httpcore==1.0.7
     # via httpx
 httpx==0.28.1
@@ -89,6 +96,11 @@ httpx==0.28.1
     # via openai
 httpx-sse==0.4.0
     # via langchain-community
+huggingface-hub==0.33.1
+    # via langchain-huggingface
+    # via sentence-transformers
+    # via tokenizers
+    # via transformers
 idna==3.10
     # via anyio
     # via httpx
@@ -96,26 +108,33 @@ idna==3.10
     # via yarl
 importlib-metadata==8.5.0
     # via opentelemetry-api
+jinja2==3.1.6
+    # via torch
 jiter==0.8.2
     # via openai
+joblib==1.5.1
+    # via scikit-learn
 jsonpatch==1.33
     # via langchain-core
 jsonpointer==3.0.0
     # via jsonpatch
-langchain==0.3.13
+langchain==0.3.26
     # via langchain-community
-langchain-community==0.3.13
+langchain-community==0.3.26
     # via rag-decision-record
-langchain-core==0.3.28
+langchain-core==0.3.67
     # via langchain
     # via langchain-community
+    # via langchain-huggingface
     # via langchain-openai
     # via langchain-text-splitters
+langchain-huggingface==0.3.0
+    # via rag-decision-record
 langchain-openai==0.2.14
     # via rag-decision-record
-langchain-text-splitters==0.3.4
+langchain-text-splitters==0.3.8
     # via langchain
-langsmith==0.2.4
+langsmith==0.4.4
     # via langchain
     # via langchain-community
     # via langchain-core
@@ -123,8 +142,12 @@ lazify==0.4.0
     # via chainlit
 literalai==0.0.623
     # via chainlit
+markupsafe==3.0.2
+    # via jinja2
 marshmallow==3.23.2
     # via dataclasses-json
+mpmath==1.3.0
+    # via sympy
 multidict==6.1.0
     # via aiohttp
     # via yarl
@@ -132,13 +155,17 @@ mypy-extensions==1.0.0
     # via typing-inspect
 nest-asyncio==1.6.0
     # via chainlit
+networkx==3.5
+    # via torch
 numpy==1.26.4
     # via chainlit
     # via faiss-cpu
     # via fastparquet
-    # via langchain
     # via langchain-community
     # via pandas
+    # via scikit-learn
+    # via scipy
+    # via transformers
 openai==1.58.1
     # via langchain-openai
 opentelemetry-api==1.28.2
@@ -176,12 +203,17 @@ packaging==23.2
     # via chainlit
     # via faiss-cpu
     # via fastparquet
+    # via huggingface-hub
     # via langchain-core
+    # via langsmith
     # via literalai
     # via marshmallow
     # via opentelemetry-instrumentation
+    # via transformers
 pandas==2.2.3
     # via fastparquet
+pillow==11.3.0
+    # via sentence-transformers
 propcache==0.2.1
     # via aiohttp
     # via yarl
@@ -219,12 +251,16 @@ python-socketio==5.12.0
 pytz==2024.2
     # via pandas
 pyyaml==6.0.2
+    # via huggingface-hub
     # via langchain
     # via langchain-community
     # via langchain-core
+    # via transformers
 regex==2024.11.6
     # via tiktoken
+    # via transformers
 requests==2.32.3
+    # via huggingface-hub
     # via langchain
     # via langchain-community
     # via langsmith
@@ -232,8 +268,20 @@ requests==2.32.3
     # via rag-decision-record
     # via requests-toolbelt
     # via tiktoken
+    # via transformers
 requests-toolbelt==1.0.0
     # via langsmith
+safetensors==0.5.3
+    # via transformers
+scikit-learn==1.7.0
+    # via sentence-transformers
+scipy==1.16.0
+    # via scikit-learn
+    # via sentence-transformers
+sentence-transformers==5.0.0
+    # via rag-decision-record
+setuptools==80.9.0
+    # via torch
 simple-websocket==1.1.0
     # via python-engineio
 six==1.17.0
@@ -247,27 +295,43 @@ sqlalchemy==2.0.36
 starlette==0.41.3
     # via chainlit
     # via fastapi
+sympy==1.14.0
+    # via torch
 syncer==2.0.3
     # via chainlit
 tenacity==9.0.0
-    # via langchain
     # via langchain-community
     # via langchain-core
+threadpoolctl==3.6.0
+    # via scikit-learn
 tiktoken==0.8.0
     # via langchain-openai
+tokenizers==0.21.2
+    # via langchain-huggingface
+    # via transformers
 tomli==2.2.1
     # via chainlit
+torch==2.7.1
+    # via sentence-transformers
 tqdm==4.67.1
+    # via huggingface-hub
     # via openai
+    # via sentence-transformers
+    # via transformers
+transformers==4.53.0
+    # via sentence-transformers
 typing-extensions==4.12.2
     # via anyio
     # via fastapi
+    # via huggingface-hub
     # via langchain-core
     # via openai
     # via opentelemetry-sdk
     # via pydantic
     # via pydantic-core
+    # via sentence-transformers
     # via sqlalchemy
+    # via torch
     # via typing-inspect
 typing-inspect==0.9.0
     # via dataclasses-json
@@ -290,3 +354,5 @@ yarl==1.18.3
     # via aiohttp
 zipp==3.21.0
     # via importlib-metadata
+zstandard==0.23.0
+    # via langsmith

--- a/requirements.lock
+++ b/requirements.lock
@@ -15,7 +15,6 @@ aiofiles==23.2.1
 aiohappyeyeballs==2.4.4
     # via aiohttp
 aiohttp==3.11.11
-    # via langchain
     # via langchain-community
 aiosignal==1.3.2
     # via aiohttp
@@ -64,6 +63,10 @@ fastapi==0.115.6
     # via chainlit
 fastparquet==2024.11.0
     # via rag-decision-record
+filelock==3.18.0
+    # via huggingface-hub
+    # via torch
+    # via transformers
 filetype==1.2.0
     # via chainlit
 frozenlist==1.5.0
@@ -71,6 +74,8 @@ frozenlist==1.5.0
     # via aiosignal
 fsspec==2024.12.0
     # via fastparquet
+    # via huggingface-hub
+    # via torch
 googleapis-common-protos==1.66.0
     # via opentelemetry-exporter-otlp-proto-grpc
     # via opentelemetry-exporter-otlp-proto-http
@@ -80,6 +85,8 @@ h11==0.14.0
     # via httpcore
     # via uvicorn
     # via wsproto
+hf-xet==1.1.5
+    # via huggingface-hub
 httpcore==1.0.7
     # via httpx
 httpx==0.28.1
@@ -89,6 +96,11 @@ httpx==0.28.1
     # via openai
 httpx-sse==0.4.0
     # via langchain-community
+huggingface-hub==0.33.1
+    # via langchain-huggingface
+    # via sentence-transformers
+    # via tokenizers
+    # via transformers
 idna==3.10
     # via anyio
     # via httpx
@@ -96,26 +108,33 @@ idna==3.10
     # via yarl
 importlib-metadata==8.5.0
     # via opentelemetry-api
+jinja2==3.1.6
+    # via torch
 jiter==0.8.2
     # via openai
+joblib==1.5.1
+    # via scikit-learn
 jsonpatch==1.33
     # via langchain-core
 jsonpointer==3.0.0
     # via jsonpatch
-langchain==0.3.13
+langchain==0.3.26
     # via langchain-community
-langchain-community==0.3.13
+langchain-community==0.3.26
     # via rag-decision-record
-langchain-core==0.3.28
+langchain-core==0.3.67
     # via langchain
     # via langchain-community
+    # via langchain-huggingface
     # via langchain-openai
     # via langchain-text-splitters
+langchain-huggingface==0.3.0
+    # via rag-decision-record
 langchain-openai==0.2.14
     # via rag-decision-record
-langchain-text-splitters==0.3.4
+langchain-text-splitters==0.3.8
     # via langchain
-langsmith==0.2.4
+langsmith==0.4.4
     # via langchain
     # via langchain-community
     # via langchain-core
@@ -123,8 +142,12 @@ lazify==0.4.0
     # via chainlit
 literalai==0.0.623
     # via chainlit
+markupsafe==3.0.2
+    # via jinja2
 marshmallow==3.23.2
     # via dataclasses-json
+mpmath==1.3.0
+    # via sympy
 multidict==6.1.0
     # via aiohttp
     # via yarl
@@ -132,13 +155,17 @@ mypy-extensions==1.0.0
     # via typing-inspect
 nest-asyncio==1.6.0
     # via chainlit
+networkx==3.5
+    # via torch
 numpy==1.26.4
     # via chainlit
     # via faiss-cpu
     # via fastparquet
-    # via langchain
     # via langchain-community
     # via pandas
+    # via scikit-learn
+    # via scipy
+    # via transformers
 openai==1.58.1
     # via langchain-openai
 opentelemetry-api==1.28.2
@@ -176,12 +203,17 @@ packaging==23.2
     # via chainlit
     # via faiss-cpu
     # via fastparquet
+    # via huggingface-hub
     # via langchain-core
+    # via langsmith
     # via literalai
     # via marshmallow
     # via opentelemetry-instrumentation
+    # via transformers
 pandas==2.2.3
     # via fastparquet
+pillow==11.3.0
+    # via sentence-transformers
 propcache==0.2.1
     # via aiohttp
     # via yarl
@@ -219,12 +251,16 @@ python-socketio==5.12.0
 pytz==2024.2
     # via pandas
 pyyaml==6.0.2
+    # via huggingface-hub
     # via langchain
     # via langchain-community
     # via langchain-core
+    # via transformers
 regex==2024.11.6
     # via tiktoken
+    # via transformers
 requests==2.32.3
+    # via huggingface-hub
     # via langchain
     # via langchain-community
     # via langsmith
@@ -232,8 +268,20 @@ requests==2.32.3
     # via rag-decision-record
     # via requests-toolbelt
     # via tiktoken
+    # via transformers
 requests-toolbelt==1.0.0
     # via langsmith
+safetensors==0.5.3
+    # via transformers
+scikit-learn==1.7.0
+    # via sentence-transformers
+scipy==1.16.0
+    # via scikit-learn
+    # via sentence-transformers
+sentence-transformers==5.0.0
+    # via rag-decision-record
+setuptools==80.9.0
+    # via torch
 simple-websocket==1.1.0
     # via python-engineio
 six==1.17.0
@@ -247,27 +295,43 @@ sqlalchemy==2.0.36
 starlette==0.41.3
     # via chainlit
     # via fastapi
+sympy==1.14.0
+    # via torch
 syncer==2.0.3
     # via chainlit
 tenacity==9.0.0
-    # via langchain
     # via langchain-community
     # via langchain-core
+threadpoolctl==3.6.0
+    # via scikit-learn
 tiktoken==0.8.0
     # via langchain-openai
+tokenizers==0.21.2
+    # via langchain-huggingface
+    # via transformers
 tomli==2.2.1
     # via chainlit
+torch==2.7.1
+    # via sentence-transformers
 tqdm==4.67.1
+    # via huggingface-hub
     # via openai
+    # via sentence-transformers
+    # via transformers
+transformers==4.53.0
+    # via sentence-transformers
 typing-extensions==4.12.2
     # via anyio
     # via fastapi
+    # via huggingface-hub
     # via langchain-core
     # via openai
     # via opentelemetry-sdk
     # via pydantic
     # via pydantic-core
+    # via sentence-transformers
     # via sqlalchemy
+    # via torch
     # via typing-inspect
 typing-inspect==0.9.0
     # via dataclasses-json
@@ -290,3 +354,5 @@ yarl==1.18.3
     # via aiohttp
 zipp==3.21.0
     # via importlib-metadata
+zstandard==0.23.0
+    # via langsmith

--- a/src/vector.py
+++ b/src/vector.py
@@ -7,7 +7,7 @@ import os
 from langchain_community.document_loaders import TextLoader
 from langchain_community.vectorstores import FAISS
 from langchain_text_splitters import CharacterTextSplitter
-from langchain_openai import OpenAIEmbeddings
+from langchain_huggingface import HuggingFaceEmbeddings
 
 # 定数
 NOTION_API_VERSION = "2022-06-28"
@@ -95,7 +95,7 @@ class NotionVectorizer:
         return documents
 
     def save_documents_to_faiss(self, documents: List[Any]) -> None:
-        embeddings = OpenAIEmbeddings(model="text-embedding-3-large")
+        embeddings = HuggingFaceEmbeddings(model_name="intfloat/multilingual-e5-large")
         vector_store = FAISS.from_documents(documents, embeddings)
         vector_store.save_local(str(self.vector_dir))
         logging.info(f"FAISS DB saved to: {self.vector_dir}")


### PR DESCRIPTION
## Summary
- Switch from OpenAI embeddings to HuggingFace multilingual-e5-large model for better multilingual support
- Update README.md to use 'rye run' commands consistently throughout the documentation
- Add langchain-huggingface and sentence-transformers dependencies to support new embedding model
- Update all dependency lock files with new ML packages and their transitive dependencies

## Test plan
- [ ] Verify vector database creation works with new HuggingFace embeddings
- [ ] Test chat functionality with updated embedding model
- [ ] Confirm all rye commands work as documented in README
- [ ] Validate dependency installation and lock files are correct

🤖 Generated with [Claude Code](https://claude.ai/code)